### PR TITLE
feat: 도메인 엔티티 설계 및 JPA 레포지토리 구현 (#1)

### DIFF
--- a/src/main/java/org/example/cardfit/domain/benefit/Benefit.java
+++ b/src/main/java/org/example/cardfit/domain/benefit/Benefit.java
@@ -1,0 +1,54 @@
+package org.example.cardfit.domain.benefit;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.cardfit.domain.card.Card;
+import org.example.cardfit.domain.category.Category;
+
+@Entity
+@Table(name = "card_benefits")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Benefit {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "card_id", nullable = false)
+    private Card card;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DiscountType discountType;
+
+    @Column(nullable = false)
+    private Double discountValue;
+
+    private Integer monthlyLimit;
+
+    private Integer minPerformance;
+
+    private Integer priority;
+
+    private Integer minPurchase;
+
+    @Builder
+    public Benefit(Card card, Category category, DiscountType discountType, Double discountValue, Integer monthlyLimit, Integer minPerformance, Integer priority, Integer minPurchase) {
+        this.card = card;
+        this.category = category;
+        this.discountType = discountType;
+        this.discountValue = discountValue;
+        this.monthlyLimit = monthlyLimit;
+        this.minPerformance = minPerformance;
+        this.priority = priority;
+        this.minPurchase = minPurchase;
+    }
+}

--- a/src/main/java/org/example/cardfit/domain/benefit/BenefitRepository.java
+++ b/src/main/java/org/example/cardfit/domain/benefit/BenefitRepository.java
@@ -1,0 +1,8 @@
+package org.example.cardfit.domain.benefit;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BenefitRepository extends JpaRepository<Benefit, Long> {
+}

--- a/src/main/java/org/example/cardfit/domain/benefit/DiscountType.java
+++ b/src/main/java/org/example/cardfit/domain/benefit/DiscountType.java
@@ -1,0 +1,14 @@
+package org.example.cardfit.domain.benefit;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DiscountType {
+    RATE("비율 할인"),
+    AMOUNT("정액 할인")
+    ;
+
+    private final String description;
+}

--- a/src/main/java/org/example/cardfit/domain/card/Card.java
+++ b/src/main/java/org/example/cardfit/domain/card/Card.java
@@ -1,0 +1,56 @@
+package org.example.cardfit.domain.card;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.cardfit.domain.benefit.Benefit;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "cards")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Card {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String issuer;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CardType cardType;
+
+    private Integer annualFee;
+
+    private Integer totalLimit;
+
+    private Integer minPerformance;
+
+    private String cardImageUrl;
+
+    @Enumerated(EnumType.STRING)
+    private CardStatus status = CardStatus.ACTIVE;
+
+    @OneToMany(mappedBy = "card", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Benefit> benefits = new ArrayList<>();
+
+    @Builder
+    public Card(String issuer, String name, CardType cardType, Integer annualFee, Integer totalLimit, Integer minPerformance, String cardImageUrl) {
+        this.issuer = issuer;
+        this.name = name;
+        this.cardType = cardType;
+        this.annualFee = annualFee;
+        this.totalLimit = totalLimit;
+        this.minPerformance = minPerformance;
+        this.cardImageUrl = cardImageUrl;
+    }
+}

--- a/src/main/java/org/example/cardfit/domain/card/CardRepository.java
+++ b/src/main/java/org/example/cardfit/domain/card/CardRepository.java
@@ -1,0 +1,11 @@
+package org.example.cardfit.domain.card;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CardRepository extends JpaRepository<Card, Long> {
+    List<Card> findAllByStatus(CardStatus status);
+}

--- a/src/main/java/org/example/cardfit/domain/card/CardStatus.java
+++ b/src/main/java/org/example/cardfit/domain/card/CardStatus.java
@@ -1,0 +1,6 @@
+package org.example.cardfit.domain.card;
+
+public enum CardStatus {
+    ACTIVE,
+    INACTIVE,
+}

--- a/src/main/java/org/example/cardfit/domain/card/CardType.java
+++ b/src/main/java/org/example/cardfit/domain/card/CardType.java
@@ -1,0 +1,6 @@
+package org.example.cardfit.domain.card;
+
+public enum CardType {
+    CREDIT,
+    CHECK,
+}

--- a/src/main/java/org/example/cardfit/domain/category/Category.java
+++ b/src/main/java/org/example/cardfit/domain/category/Category.java
@@ -1,0 +1,28 @@
+package org.example.cardfit.domain.category;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "categories")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String keywords;
+
+    public Category(String name, String keywords) {
+        this.name = name;
+        this.keywords = keywords;
+    }
+
+}

--- a/src/main/java/org/example/cardfit/domain/category/CategoryRepository.java
+++ b/src/main/java/org/example/cardfit/domain/category/CategoryRepository.java
@@ -1,0 +1,14 @@
+package org.example.cardfit.domain.category;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+    Optional<Category> findByName(String name);
+
+    List<Category> findByKeywordsContaining(String keyword);
+}

--- a/src/test/java/org/example/cardfit/domain/card/CardRepositoryTest.java
+++ b/src/test/java/org/example/cardfit/domain/card/CardRepositoryTest.java
@@ -1,0 +1,52 @@
+package org.example.cardfit.domain.card;
+
+import org.example.cardfit.domain.benefit.Benefit;
+import org.example.cardfit.domain.benefit.DiscountType;
+import org.example.cardfit.domain.category.Category;
+import org.example.cardfit.domain.category.CategoryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class CardRepositoryTest {
+
+    @Autowired
+    private CardRepository cardRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Test
+    @DisplayName("카드를 저장할 때 혜택 리스트가 함께 저장되고 조회되어야 한다")
+    void card_benefits_load_test() {
+        Category category = new Category("식비", "스타벅스,식당");
+        categoryRepository.save(category);
+
+        Card card = Card.builder()
+                .issuer("신한")
+                .name("Mr.Life")
+                .cardType(CardType.CREDIT)
+                .build();
+
+        Benefit benefit = Benefit.builder()
+                .card(card)
+                .category(category)
+                .discountType(DiscountType.RATE)
+                .discountValue(10.0)
+                .build();
+
+        card.getBenefits().add(benefit);
+
+        Card savedCard = cardRepository.save(card);
+        cardRepository.flush();
+
+        Card findCard = cardRepository.findById(savedCard.getId()).orElseThrow();
+
+        assert (!findCard.getBenefits().isEmpty());
+        assert (findCard.getBenefits().get(0).getDiscountValue() == 10.0);
+    }
+}


### PR DESCRIPTION
## 📌 개요
- 도메인 엔티티 설계 및 JPA 연관관계 구축

## 📝 작업 내용
- [x] Card, Benefit, Category 엔티티 생성
- [x] @OneToMany, @ManyToOne 양방향 연관관계 매핑
- [x] CardRepository, BenefitRepository, CategoryRepository 인터페이스 생성
- [x] Enum(CardType, CardStatus, DiscountType) 정의

## 🧪 테스트 결과
- `CardRepositoryTest`: 카드 저장 시 혜택 리스트가 함께 저장되고 로드되는지 검증 완료 (Pass)

## 🔗 관련 이슈
- close #1