### PR TITLE
  feat: 엑셀 파싱 및 LLM 카테고리 매핑 구현 (#3)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     // Excel (Apache POI)
-    implementation 'org.apache.poi:poi:5.5.1'
+    implementation 'org.apache.poi:poi-ooxml:5.5.1'
 
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'

--- a/src/main/java/org/example/cardfit/domain/category/CategoryType.java
+++ b/src/main/java/org/example/cardfit/domain/category/CategoryType.java
@@ -18,6 +18,7 @@ public enum CategoryType {
     CULTURE_SUBSCRIPTION(7L, "문화/구독"),
     MEDICAL(8L, "의료/병원"),
     EDUCATION(9L, "교육/학원"),
+    UTILITIES(10L, "공과금/생활비"),
     ETC(0L, "기타");
 
     private final Long id;

--- a/src/main/java/org/example/cardfit/domain/category/CategoryType.java
+++ b/src/main/java/org/example/cardfit/domain/category/CategoryType.java
@@ -24,9 +24,11 @@ public enum CategoryType {
     private final Long id;
     private final String name;
 
+    private static final String PROMPT_GUIDE = Arrays.stream(values())
+            .map(c -> c.id + ":" + c.name)
+            .collect(Collectors.joining(", "));
+
     public static String getPromptGuide() {
-        return Arrays.stream(values())
-                .map(c -> c.id + ":" + c.name)
-                .collect(Collectors.joining(", "));
+        return PROMPT_GUIDE;
     }
 }

--- a/src/main/java/org/example/cardfit/domain/category/CategoryType.java
+++ b/src/main/java/org/example/cardfit/domain/category/CategoryType.java
@@ -1,0 +1,31 @@
+package org.example.cardfit.domain.category;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+@Getter
+@RequiredArgsConstructor
+public enum CategoryType {
+    COFFEE(1L, "커피/카페"),
+    DINING(2L, "외식/배달"),
+    TRANSPORT(3L, "대중교통/택시"),
+    ONLINE_SHOPPING(4L, "온라인 쇼핑"),
+    MART_CONVENIENCE(5L, "마트/편의점"),
+    GAS(6L, "주유"),
+    CULTURE_SUBSCRIPTION(7L, "문화/구독"),
+    MEDICAL(8L, "의료/병원"),
+    EDUCATION(9L, "교육/학원"),
+    ETC(0L, "기타");
+
+    private final Long id;
+    private final String name;
+
+    public static String getPromptGuide() {
+        return Arrays.stream(values())
+                .map(c -> c.id + ":" + c.name)
+                .collect(Collectors.joining(", "));
+    }
+}

--- a/src/main/java/org/example/cardfit/infrastructure/excel/ColumnMapping.java
+++ b/src/main/java/org/example/cardfit/infrastructure/excel/ColumnMapping.java
@@ -3,6 +3,7 @@ package org.example.cardfit.infrastructure.excel;
 public record ColumnMapping(
         int dateIndex,
         int storeNameIndex,
-        int amountIndex
+        int amountIndex,
+        int typeIndex
 ) {
 }

--- a/src/main/java/org/example/cardfit/infrastructure/excel/ColumnMapping.java
+++ b/src/main/java/org/example/cardfit/infrastructure/excel/ColumnMapping.java
@@ -1,0 +1,8 @@
+package org.example.cardfit.infrastructure.excel;
+
+public record ColumnMapping(
+        int dateIndex,
+        int storeNameIndex,
+        int amountIndex
+) {
+}

--- a/src/main/java/org/example/cardfit/infrastructure/excel/ExcelParser.java
+++ b/src/main/java/org/example/cardfit/infrastructure/excel/ExcelParser.java
@@ -1,0 +1,10 @@
+package org.example.cardfit.infrastructure.excel;
+
+import org.example.cardfit.recommendation.dto.RawExpense;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface ExcelParser {
+    List<RawExpense> parse(MultipartFile file);
+}

--- a/src/main/java/org/example/cardfit/infrastructure/excel/HeaderDetector.java
+++ b/src/main/java/org/example/cardfit/infrastructure/excel/HeaderDetector.java
@@ -14,14 +14,16 @@ public class HeaderDetector {
     private static final List<String> DATE_KEYWORDS = List.of("날짜", "일자", "이용일", "사용일", "거래일", "date");
     private static final List<String> STORE_KEYWORDS = List.of("가맹점", "상호", "거래처", "내역", "사용처", "store");
     private static final List<String> AMOUNT_KEYWORDS = List.of("금액", "결제", "승인", "이용금액", "amount");
+    private static final List<String> TYPE_KEYWORDS = List.of("수입", "지출", "구분", "유형", "입출금", "type");
 
     public ColumnMapping detect(List<String> headers) {
         int dateIdx = findByKeywords(headers, DATE_KEYWORDS);
         int storeIdx = findByKeywords(headers, STORE_KEYWORDS);
         int amountIdx = findByKeywords(headers, AMOUNT_KEYWORDS);
+        int typeIdx = findByKeywords(headers, TYPE_KEYWORDS);
 
         if (dateIdx >= 0 && storeIdx >= 0 && amountIdx >= 0) {
-            return new ColumnMapping(dateIdx, storeIdx, amountIdx);
+            return new ColumnMapping(dateIdx, storeIdx, amountIdx, typeIdx);
         }
 
         return detectByLLM(headers);

--- a/src/main/java/org/example/cardfit/infrastructure/excel/HeaderDetector.java
+++ b/src/main/java/org/example/cardfit/infrastructure/excel/HeaderDetector.java
@@ -1,0 +1,47 @@
+package org.example.cardfit.infrastructure.excel;
+
+import lombok.RequiredArgsConstructor;
+import org.example.cardfit.infrastructure.llm.LLMClient;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class HeaderDetector {
+    private final LLMClient llmClient;
+
+    private static final List<String> DATE_KEYWORDS = List.of("날짜", "일자", "이용일", "사용일", "거래일", "date");
+    private static final List<String> STORE_KEYWORDS = List.of("가맹점", "상호", "거래처", "내역", "사용처", "store");
+    private static final List<String> AMOUNT_KEYWORDS = List.of("금액", "결제", "승인", "이용금액", "amount");
+
+    public ColumnMapping detect(List<String> headers) {
+        int dateIdx = findByKeywords(headers, DATE_KEYWORDS);
+        int storeIdx = findByKeywords(headers, STORE_KEYWORDS);
+        int amountIdx = findByKeywords(headers, AMOUNT_KEYWORDS);
+
+        if (dateIdx >= 0 && storeIdx >= 0 && amountIdx >= 0) {
+            return new ColumnMapping(dateIdx, storeIdx, amountIdx);
+        }
+
+        return detectByLLM(headers);
+    }
+
+    private int findByKeywords(List<String> headers, List<String> keywords) {
+        for (int i = 0; i < headers.size(); i++) {
+            String header = headers.get(i).toLowerCase();
+            for (String keyword: keywords) {
+                if (header.contains(keyword.toLowerCase())) return i;
+            }
+        }
+        return -1;
+    }
+
+    private ColumnMapping detectByLLM(List<String> headers) {
+        try {
+            return llmClient.detectColumns(headers);
+        } catch (Exception e) {
+            throw new RuntimeException("헤더 자동감지 실패. 지원하지 않는 엑셀 양식입니다.");
+        }
+    }
+}

--- a/src/main/java/org/example/cardfit/infrastructure/excel/HeaderDetector.java
+++ b/src/main/java/org/example/cardfit/infrastructure/excel/HeaderDetector.java
@@ -22,11 +22,21 @@ public class HeaderDetector {
         int amountIdx = findByKeywords(headers, AMOUNT_KEYWORDS);
         int typeIdx = findByKeywords(headers, TYPE_KEYWORDS);
 
+        ColumnMapping mapping;
         if (dateIdx >= 0 && storeIdx >= 0 && amountIdx >= 0) {
-            return new ColumnMapping(dateIdx, storeIdx, amountIdx, typeIdx);
+            mapping = new ColumnMapping(dateIdx, storeIdx, amountIdx, typeIdx);
+        } else {
+            mapping = detectByLLM(headers);
         }
 
-        return detectByLLM(headers);
+        validateMapping(mapping);
+        return mapping;
+    }
+
+    private void validateMapping(ColumnMapping mapping) {
+        if (mapping.dateIndex() < 0 || mapping.storeNameIndex() < 0 || mapping.amountIndex() < 0) {
+            throw new IllegalArgumentException("필수 열(날짜, 가맹점/내역, 금액)을 찾을 수 없습니다.");
+        }
     }
 
     private int findByKeywords(List<String> headers, List<String> keywords) {

--- a/src/main/java/org/example/cardfit/infrastructure/excel/PoiExcelParser.java
+++ b/src/main/java/org/example/cardfit/infrastructure/excel/PoiExcelParser.java
@@ -1,0 +1,63 @@
+package org.example.cardfit.infrastructure.excel;
+
+import org.apache.poi.ss.usermodel.*;
+import org.example.cardfit.recommendation.dto.RawExpense;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.InputStream;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class PoiExcelParser implements ExcelParser{
+    @Override
+    public List<RawExpense> parse(MultipartFile file) {
+        List<RawExpense> expenses = new ArrayList<>();
+
+        try (InputStream is = file.getInputStream();
+             Workbook workbook = WorkbookFactory.create(is)) {
+
+            Sheet sheet = workbook.getSheetAt(0);
+            for (int i = 1; i <= sheet.getLastRowNum(); i++) {
+                Row row = sheet.getRow(i);
+                if (row == null || isRowEmpty(row)) continue;
+
+                LocalDate date = getLocalDate(row.getCell((0)));
+                String storeName = getStringValue(row.getCell(1));
+                long amount = (long) getNumericValue(row.getCell(2));
+
+                expenses.add(new RawExpense(date, storeName, amount));
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("엑셀 파일 파싱 중 오류가 발생했습니다: " + e.getMessage());
+        }
+
+        return expenses;
+    }
+
+    private boolean isRowEmpty(Row row) {
+        for (int c = row.getFirstCellNum(); c < row.getLastCellNum(); c++) {
+            Cell cell = row.getCell(c);
+            if (cell != null && cell.getCellType() != CellType.BLANK) return false;
+        }
+        return true;
+     }
+
+    private LocalDate getLocalDate(Cell cell) {
+        if (cell.getCellType() == CellType.NUMERIC && DateUtil.isCellDateFormatted(cell)) {
+            return cell.getDateCellValue().toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+        }
+        return LocalDate.now();
+    }
+
+    private String getStringValue(Cell cell) {
+        return cell.getCellType() == CellType.STRING ? cell.getStringCellValue() : "";
+    }
+
+    private double getNumericValue(Cell cell) {
+        return cell.getCellType() == CellType.NUMERIC ? cell.getNumericCellValue() : 0.0;
+    }
+}

--- a/src/main/java/org/example/cardfit/infrastructure/excel/PoiExcelParser.java
+++ b/src/main/java/org/example/cardfit/infrastructure/excel/PoiExcelParser.java
@@ -1,5 +1,6 @@
 package org.example.cardfit.infrastructure.excel;
 
+import lombok.RequiredArgsConstructor;
 import org.apache.poi.ss.usermodel.*;
 import org.example.cardfit.recommendation.dto.RawExpense;
 import org.springframework.stereotype.Component;
@@ -12,30 +13,39 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Component
+@RequiredArgsConstructor
 public class PoiExcelParser implements ExcelParser{
+
+    private final HeaderDetector headerDetector;
+
     @Override
     public List<RawExpense> parse(MultipartFile file) {
-        List<RawExpense> expenses = new ArrayList<>();
-
         try (InputStream is = file.getInputStream();
              Workbook workbook = WorkbookFactory.create(is)) {
 
             Sheet sheet = workbook.getSheetAt(0);
+
+            Row headerRow = sheet.getRow(0);
+            List<String> headers = extractHeaders(headerRow);
+
+            ColumnMapping mapping = headerDetector.detect(headers);
+
+            List<RawExpense> expenses = new ArrayList<>();
             for (int i = 1; i <= sheet.getLastRowNum(); i++) {
                 Row row = sheet.getRow(i);
                 if (row == null || isRowEmpty(row)) continue;
 
-                LocalDate date = getLocalDate(row.getCell((0)));
-                String storeName = getStringValue(row.getCell(1));
-                long amount = (long) getNumericValue(row.getCell(2));
+                LocalDate date = getLocalDate(row.getCell(mapping.dateIndex()));
+                String storeName = getStringValue(row.getCell(mapping.storeNameIndex()));
+                long amount = (long) getNumericValue(row.getCell(mapping.amountIndex()));
 
                 expenses.add(new RawExpense(date, storeName, amount));
             }
+            return expenses;
+
         } catch (Exception e) {
             throw new RuntimeException("엑셀 파일 파싱 중 오류가 발생했습니다: " + e.getMessage());
         }
-
-        return expenses;
     }
 
     private boolean isRowEmpty(Row row) {
@@ -47,6 +57,7 @@ public class PoiExcelParser implements ExcelParser{
      }
 
     private LocalDate getLocalDate(Cell cell) {
+        if (cell == null) return LocalDate.now();
         if (cell.getCellType() == CellType.NUMERIC && DateUtil.isCellDateFormatted(cell)) {
             return cell.getDateCellValue().toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
         }
@@ -54,10 +65,20 @@ public class PoiExcelParser implements ExcelParser{
     }
 
     private String getStringValue(Cell cell) {
+        if (cell == null) return "";
         return cell.getCellType() == CellType.STRING ? cell.getStringCellValue() : "";
     }
 
     private double getNumericValue(Cell cell) {
+        if (cell == null) return 0.0;
         return cell.getCellType() == CellType.NUMERIC ? cell.getNumericCellValue() : 0.0;
+    }
+
+    private List<String> extractHeaders(Row row) {
+        List<String> headers = new ArrayList<>();
+        for (int i = 0; i < row.getLastCellNum(); i++) {
+            headers.add(getStringValue(row.getCell(i)));
+        }
+        return headers;
     }
 }

--- a/src/main/java/org/example/cardfit/infrastructure/excel/PoiExcelParser.java
+++ b/src/main/java/org/example/cardfit/infrastructure/excel/PoiExcelParser.java
@@ -17,6 +17,7 @@ import java.util.List;
 public class PoiExcelParser implements ExcelParser{
 
     private final HeaderDetector headerDetector;
+    private static final List<String> EXPENSE_KEYWORDS = List.of("지출", "지급", "사용", "결제", "expense", "out");
 
     @Override
     public List<RawExpense> parse(MultipartFile file) {
@@ -35,9 +36,18 @@ public class PoiExcelParser implements ExcelParser{
                 Row row = sheet.getRow(i);
                 if (row == null || isRowEmpty(row)) continue;
 
+                double rawAmount = getNumericValue(row.getCell(mapping.amountIndex()));
+
+                if (mapping.typeIndex() >= 0) {
+                    String type = getStringValue(row.getCell(mapping.typeIndex()));
+                    if(!isExpense(type)) continue;
+                } else {
+                    if (rawAmount >= 0) continue;
+                }
+
                 LocalDate date = getLocalDate(row.getCell(mapping.dateIndex()));
                 String storeName = getStringValue(row.getCell(mapping.storeNameIndex()));
-                long amount = (long) getNumericValue(row.getCell(mapping.amountIndex()));
+                long amount = (long) Math.abs(rawAmount);
 
                 expenses.add(new RawExpense(date, storeName, amount));
             }
@@ -54,6 +64,11 @@ public class PoiExcelParser implements ExcelParser{
             if (cell != null && cell.getCellType() != CellType.BLANK) return false;
         }
         return true;
+     }
+
+     private boolean isExpense(String type) {
+         String lower = type.toLowerCase();
+         return EXPENSE_KEYWORDS.stream().anyMatch(lower::contains);
      }
 
     private LocalDate getLocalDate(Cell cell) {

--- a/src/main/java/org/example/cardfit/infrastructure/excel/PoiExcelParser.java
+++ b/src/main/java/org/example/cardfit/infrastructure/excel/PoiExcelParser.java
@@ -27,6 +27,8 @@ public class PoiExcelParser implements ExcelParser{
             Sheet sheet = workbook.getSheetAt(0);
 
             Row headerRow = sheet.getRow(0);
+            if (headerRow == null) throw new RuntimeException("엑셀 파일에 헤더 행이 없습니다");
+
             List<String> headers = extractHeaders(headerRow);
 
             ColumnMapping mapping = headerDetector.detect(headers);

--- a/src/main/java/org/example/cardfit/infrastructure/llm/GeminiClient.java
+++ b/src/main/java/org/example/cardfit/infrastructure/llm/GeminiClient.java
@@ -1,0 +1,102 @@
+package org.example.cardfit.infrastructure.llm;
+
+import org.example.cardfit.domain.category.CategoryType;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.JsonNodeType;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class GeminiClient implements LLMClient {
+
+    private final RestClient restClient;
+    private final ObjectMapper objectMapper;
+
+    @Value("${gemini.api.url}")
+    private String apiUrl;
+
+    @Value("${gemini.api.key}")
+    private String apiKey;
+
+    public GeminiClient(ObjectMapper objectMapper) {
+        this.restClient = RestClient.create();
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public String classify(List<String> storeNames) {
+        String prompt = createPrompt(storeNames);
+        String urlWithKey = apiUrl + "?key=" + apiKey;
+        Map<String, Object> requestBody = Map.of(
+                "contents", List.of(
+                        Map.of("parts", List.of(Map.of("text", prompt)))
+                ),
+                "generationConfig", Map.of(
+                        "response_mime_type", "application/json"
+                )
+        );
+        String rawResponse = restClient.post()
+                .uri(urlWithKey)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(requestBody)
+                .retrieve()
+                .body(String.class);
+
+        return extractTextFromResponse(rawResponse);
+    }
+
+    private String extractTextFromResponse(String rawResponse) {
+        try {
+            JsonNode root = objectMapper.readTree(cleanJsonText(rawResponse));
+            JsonNode textNode = root.path("candidates").get(0)
+                    .path("content")
+                    .path("parts").get(0)
+                    .path("text");
+
+            if (textNode.getNodeType() == JsonNodeType.STRING) {
+                return textNode.asString();
+            }
+
+            return "";
+        } catch (Exception e) {
+            throw new RuntimeException("Gemini API 응답 파싱 실패");
+        }
+    }
+
+    private String cleanJsonText(String rawText) {
+        return rawText.replace("```json", "")
+                .replace("```", "")
+                .trim();
+    }
+
+    private String createPrompt(List<String> storeNames) {
+        String stores = String.join(", ", storeNames);
+        String categoryGuide = CategoryType.getPromptGuide();
+
+        return String.format("""
+                너는 지출 내역을 숫자로만 분류하는 데이터 처리 봇이야.
+                설명은 생략하고 오직 JSON 데이터만 출력해.
+                
+                [분류 규칙 (ID:이름)]
+                %s
+                
+                [출력 형식]
+                - 반드시 categoryId 필드에 숫자를 넣어야 함.
+                - 가맹점 및 내역은 원본 그대로 유지할 것.
+                - 카테고리가 모호하면 기타(0)로 분류할 것.
+                
+                [출력 예시]
+                [{"storeName": "스타벅스", "categoryId": 1}]
+                
+                [대상 가맹점 및 내역 리스트]
+                %s
+                
+                """, categoryGuide, stores);
+    }
+}

--- a/src/main/java/org/example/cardfit/infrastructure/llm/GeminiClient.java
+++ b/src/main/java/org/example/cardfit/infrastructure/llm/GeminiClient.java
@@ -1,6 +1,7 @@
 package org.example.cardfit.infrastructure.llm;
 
 import org.example.cardfit.domain.category.CategoryType;
+import org.example.cardfit.infrastructure.excel.ColumnMapping;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -29,10 +30,9 @@ public class GeminiClient implements LLMClient {
         this.objectMapper = objectMapper;
     }
 
-    @Override
-    public String classify(List<String> storeNames) {
-        String prompt = createPrompt(storeNames);
+    private String callGeminiApi(String prompt) {
         String urlWithKey = apiUrl + "?key=" + apiKey;
+
         Map<String, Object> requestBody = Map.of(
                 "contents", List.of(
                         Map.of("parts", List.of(Map.of("text", prompt)))
@@ -49,6 +49,13 @@ public class GeminiClient implements LLMClient {
                 .body(String.class);
 
         return extractTextFromResponse(rawResponse);
+    }
+
+
+    @Override
+    public String classify(List<String> storeNames) {
+        String prompt = createPrompt(storeNames);
+        return callGeminiApi(prompt);
     }
 
     private String extractTextFromResponse(String rawResponse) {
@@ -98,5 +105,50 @@ public class GeminiClient implements LLMClient {
                 %s
                 
                 """, categoryGuide, stores);
+    }
+
+    @Override
+    public ColumnMapping detectColumns(List<String> headers) {
+        String prompt = createHeaderDetectPrompt(headers);
+        String jsonText = callGeminiApi(prompt);
+        return parseColumnMapping(jsonText);
+    }
+
+    private String createHeaderDetectPrompt(List<String> headers) {
+        String headerList = String.join(",", headers);
+
+        return String.format("""
+                너는 엑셀 헤더를 분석하는 데이터 처리 봇이야.
+                설명은 생략하고 오직 JSON 데이터만 출력해.
+                
+                [분석 대상 헤더 목록]
+                %s
+                
+                [분석 규칙]
+                - dateIndex: 날짜/일자/이용일 등 날짜 관련 열의 인덱스 (0부터 시작)
+                - storeNameIndex: 가맹점/상호/거래처/내역 등 가맹점명 및 내역 관련 열의 인덱스
+                - amountIndex: 금액/결제/승인금액 등 금액 관련 열의 인덱스
+                
+                [출력 형식]
+                {"dateIndex": 0, "storeNameIndex": 1, "amountIndex": 2}
+                
+                [주의]
+                - 인덱스는 0부터 시작
+                - 해당 열을 찾을 수 없으면 -1 반환
+                """, headerList);
+    }
+
+    private ColumnMapping parseColumnMapping(String jsonText) {
+        try {
+            JsonNode node = objectMapper.readTree(jsonText);
+
+            int dateIndex = node.path("dateIndex").asInt(-1);
+            int storeNameIndex = node.path("storeNameIndex").asInt(-1);
+            int amountIndex = node.path("amountIndex").asInt(-1);
+
+            return new ColumnMapping(dateIndex, storeNameIndex, amountIndex);
+        } catch (Exception e) {
+            throw new RuntimeException("헤더 감지 응답 파싱 실패: " + e.getMessage());
+        }
     }
 }

--- a/src/main/java/org/example/cardfit/infrastructure/llm/GeminiClient.java
+++ b/src/main/java/org/example/cardfit/infrastructure/llm/GeminiClient.java
@@ -128,9 +128,10 @@ public class GeminiClient implements LLMClient {
                 - dateIndex: 날짜/일자/이용일 등 날짜 관련 열의 인덱스 (0부터 시작)
                 - storeNameIndex: 가맹점/상호/거래처/내역 등 가맹점명 및 내역 관련 열의 인덱스
                 - amountIndex: 금액/결제/승인금액 등 금액 관련 열의 인덱스
+                - typeIndex: 수입/지출 구분 열의 인덱스
                 
                 [출력 형식]
-                {"dateIndex": 0, "storeNameIndex": 1, "amountIndex": 2}
+                {"dateIndex": 0, "storeNameIndex": 1, "amountIndex": 2, "typeIndex": 3}
                 
                 [주의]
                 - 인덱스는 0부터 시작
@@ -145,8 +146,9 @@ public class GeminiClient implements LLMClient {
             int dateIndex = node.path("dateIndex").asInt(-1);
             int storeNameIndex = node.path("storeNameIndex").asInt(-1);
             int amountIndex = node.path("amountIndex").asInt(-1);
+            int typeIndex = node.path("typeIndex").asInt(-1);
 
-            return new ColumnMapping(dateIndex, storeNameIndex, amountIndex);
+            return new ColumnMapping(dateIndex, storeNameIndex, amountIndex, typeIndex);
         } catch (Exception e) {
             throw new RuntimeException("헤더 감지 응답 파싱 실패: " + e.getMessage());
         }

--- a/src/main/java/org/example/cardfit/infrastructure/llm/LLMClient.java
+++ b/src/main/java/org/example/cardfit/infrastructure/llm/LLMClient.java
@@ -1,0 +1,7 @@
+package org.example.cardfit.infrastructure.llm;
+
+import java.util.List;
+
+public interface LLMClient {
+    String classify(List<String> storeNames);
+}

--- a/src/main/java/org/example/cardfit/infrastructure/llm/LLMClient.java
+++ b/src/main/java/org/example/cardfit/infrastructure/llm/LLMClient.java
@@ -1,7 +1,11 @@
 package org.example.cardfit.infrastructure.llm;
 
+import org.example.cardfit.infrastructure.excel.ColumnMapping;
+
 import java.util.List;
 
 public interface LLMClient {
     String classify(List<String> storeNames);
+
+    ColumnMapping detectColumns(List<String> headers);
 }

--- a/src/main/java/org/example/cardfit/recommendation/controller/RecommendationApiController.java
+++ b/src/main/java/org/example/cardfit/recommendation/controller/RecommendationApiController.java
@@ -1,12 +1,12 @@
 package org.example.cardfit.recommendation.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.example.cardfit.recommendation.dto.RecommendationResponse;
-import org.example.cardfit.recommendation.form.ManualInputForm;
-import org.example.cardfit.recommendation.mapper.RecommendationMapper;
+import org.example.cardfit.recommendation.dto.ExpenseMappingResult;
+import org.example.cardfit.recommendation.form.ExcelUploadForm;
+import org.example.cardfit.recommendation.service.ExpenseParseService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,15 +17,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class RecommendationApiController {
 
-    private final RecommendationMapper recommendationMapper;
+    private final ExpenseParseService expenseParseService;
 
-    @PostMapping("/manual")
-    public ResponseEntity<RecommendationResponse> getManualRecommendation(@RequestBody ManualInputForm form) {
-        var requests = recommendationMapper.toSummaryRequest(form);
-        System.out.println("가공된 데이터 개수: " + requests.size());
-
-        return ResponseEntity.ok(new RecommendationResponse(
-                "테스트카드", 0, List.of(), "엔진 구현 중", 0
-        ));
+    @PostMapping("/upload")
+    public ResponseEntity<List<ExpenseMappingResult>> uploadExcel(@ModelAttribute ExcelUploadForm form) {
+        List<ExpenseMappingResult> results = expenseParseService.parseAndClassify(form.file());
+        return ResponseEntity.ok(results);
     }
 }

--- a/src/main/java/org/example/cardfit/recommendation/controller/RecommendationViewController.java
+++ b/src/main/java/org/example/cardfit/recommendation/controller/RecommendationViewController.java
@@ -1,20 +1,36 @@
 package org.example.cardfit.recommendation.controller;
 
+import org.example.cardfit.domain.category.CategoryType;
 import org.example.cardfit.recommendation.form.ManualInputForm;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 @Controller
 @RequestMapping("/recommendation")
 public class RecommendationViewController {
 
-    @GetMapping("/manual")
-    public String manualInputPage(Model model) {
-        model.addAttribute("manualInputForm", new ManualInputForm(new ArrayList<>(), 0L));
+    @GetMapping("/input")
+    public String inputPage(Model model) {
+        model.addAttribute("categories", CategoryType.values());
+
+        List<Map<String, Object>> categoriesForJs = Arrays.stream(CategoryType.values())
+                .map(cat -> Map.<String, Object>of("id", cat.getId(), "name", cat.getName()))
+                .toList();
+        model.addAttribute("categoriesForJs", categoriesForJs);
+
         return "recommendation/input";
+    }
+
+    @PostMapping("/result")
+    public String showResult(@ModelAttribute ManualInputForm form, Model model) {
+        return "recommendation/result";
     }
 }

--- a/src/main/java/org/example/cardfit/recommendation/dto/ExpenseMappingResult.java
+++ b/src/main/java/org/example/cardfit/recommendation/dto/ExpenseMappingResult.java
@@ -1,0 +1,11 @@
+package org.example.cardfit.recommendation.dto;
+
+import org.example.cardfit.domain.category.CategoryType;
+
+public record ExpenseMappingResult(
+        String storeName,
+        Long amount,
+        String date,
+        CategoryType categoryType
+) {
+}

--- a/src/main/java/org/example/cardfit/recommendation/dto/ExpenseMappingResult.java
+++ b/src/main/java/org/example/cardfit/recommendation/dto/ExpenseMappingResult.java
@@ -1,11 +1,9 @@
 package org.example.cardfit.recommendation.dto;
 
-import org.example.cardfit.domain.category.CategoryType;
-
 public record ExpenseMappingResult(
         String storeName,
         Long amount,
         String date,
-        CategoryType categoryType
+        Long categoryId
 ) {
 }

--- a/src/main/java/org/example/cardfit/recommendation/dto/RawExpense.java
+++ b/src/main/java/org/example/cardfit/recommendation/dto/RawExpense.java
@@ -1,0 +1,10 @@
+package org.example.cardfit.recommendation.dto;
+
+import java.time.LocalDate;
+
+public record RawExpense(
+        LocalDate date,
+        String storeName,
+        Long amount
+) {
+}

--- a/src/main/java/org/example/cardfit/recommendation/service/ExpenseParseService.java
+++ b/src/main/java/org/example/cardfit/recommendation/service/ExpenseParseService.java
@@ -1,0 +1,69 @@
+package org.example.cardfit.recommendation.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.cardfit.domain.category.CategoryType;
+import org.example.cardfit.infrastructure.excel.PoiExcelParser;
+import org.example.cardfit.infrastructure.llm.LLMClient;
+import org.example.cardfit.recommendation.dto.ExpenseMappingResult;
+import org.example.cardfit.recommendation.dto.RawExpense;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ExpenseParseService {
+
+    private final PoiExcelParser excelParser;
+    private final LLMClient llmClient;
+    private final ObjectMapper objectMapper;
+
+    public List<ExpenseMappingResult> parseAndClassify(MultipartFile file) {
+        var rawExpenses = excelParser.parse(file);
+
+        List<String> distinctStores = rawExpenses.stream()
+                .map(RawExpense::storeName)
+                .distinct()
+                .toList();
+
+        Map<String, Long> categoryMap = classifyStores(distinctStores);
+
+        return rawExpenses.stream()
+                .map(raw -> new ExpenseMappingResult(
+                        raw.storeName(),
+                        Long.valueOf(raw.amount().toString()),
+                        raw.date().toString(),
+                        findCategory(categoryMap.get(raw.storeName()))
+                ))
+                .toList();
+    }
+
+    private Map<String, Long> classifyStores(List<String> stores) {
+        String jsonResult = llmClient.classify(stores);
+
+        try {
+            List<Map<String, Object>> list = objectMapper.readValue(jsonResult, new TypeReference<>(){});
+            return list.stream().collect(Collectors.toMap(
+                    m -> (String) m.get("storeName"),
+                    m -> Long.valueOf(m.get("categoryId").toString()),
+                    (existing, replacement) -> existing
+            ));
+        } catch (Exception e) {
+            return Collections.emptyMap();
+        }
+    }
+
+    private CategoryType findCategory(Long id) {
+        return Arrays.stream(CategoryType.values())
+                .filter(c -> c.getId().equals(id))
+                .findFirst()
+                .orElse(CategoryType.ETC);
+    }
+}

--- a/src/main/java/org/example/cardfit/recommendation/service/ExpenseParseService.java
+++ b/src/main/java/org/example/cardfit/recommendation/service/ExpenseParseService.java
@@ -24,6 +24,8 @@ public class ExpenseParseService {
     private final ObjectMapper objectMapper;
 
     public List<ExpenseMappingResult> parseAndClassify(MultipartFile file) {
+        validateFile(file);
+
         var rawExpenses = excelParser.parse(file);
 
         List<String> distinctStores = rawExpenses.stream()
@@ -41,6 +43,14 @@ public class ExpenseParseService {
                         categoryMap.getOrDefault(raw.storeName(), 0L)
                 ))
                 .toList();
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) throw new IllegalArgumentException("파일이 비어있습니다");
+
+        String filename = file.getOriginalFilename();
+        if (filename == null || (!filename.endsWith(".xlsx") && !filename.endsWith(".xls")))
+            throw new IllegalArgumentException("엑셀 파일(.xlsx, .xls)만 업로드 가능합니다.");
     }
 
     private Map<String, Long> classifyStores(List<String> stores) {

--- a/src/main/java/org/example/cardfit/recommendation/service/ExpenseParseService.java
+++ b/src/main/java/org/example/cardfit/recommendation/service/ExpenseParseService.java
@@ -1,7 +1,6 @@
 package org.example.cardfit.recommendation.service;
 
 import lombok.RequiredArgsConstructor;
-import org.example.cardfit.domain.category.CategoryType;
 import org.example.cardfit.infrastructure.excel.PoiExcelParser;
 import org.example.cardfit.infrastructure.llm.LLMClient;
 import org.example.cardfit.recommendation.dto.ExpenseMappingResult;
@@ -11,7 +10,6 @@ import org.springframework.web.multipart.MultipartFile;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.ObjectMapper;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -49,7 +47,8 @@ public class ExpenseParseService {
         String jsonResult = llmClient.classify(stores);
 
         try {
-            List<Map<String, Object>> list = objectMapper.readValue(jsonResult, new TypeReference<>(){});
+            List<Map<String, Object>> list = objectMapper.readValue(jsonResult, new TypeReference<>() {
+            });
             return list.stream().collect(Collectors.toMap(
                     m -> (String) m.get("storeName"),
                     m -> Long.valueOf(m.get("categoryId").toString()),

--- a/src/main/java/org/example/cardfit/recommendation/service/ExpenseParseService.java
+++ b/src/main/java/org/example/cardfit/recommendation/service/ExpenseParseService.java
@@ -49,7 +49,10 @@ public class ExpenseParseService {
         if (file == null || file.isEmpty()) throw new IllegalArgumentException("파일이 비어있습니다");
 
         String filename = file.getOriginalFilename();
-        if (filename == null || (!filename.endsWith(".xlsx") && !filename.endsWith(".xls")))
+        if (filename == null) throw new IllegalArgumentException("파일명이 없습니다.");
+
+        String lower = filename.toLowerCase();
+        if (!lower.endsWith(".xlsx") && !lower.endsWith(".xls"))
             throw new IllegalArgumentException("엑셀 파일(.xlsx, .xls)만 업로드 가능합니다.");
     }
 

--- a/src/main/java/org/example/cardfit/recommendation/service/ExpenseParseService.java
+++ b/src/main/java/org/example/cardfit/recommendation/service/ExpenseParseService.java
@@ -40,7 +40,7 @@ public class ExpenseParseService {
                         raw.storeName(),
                         Long.valueOf(raw.amount().toString()),
                         raw.date().toString(),
-                        findCategory(categoryMap.get(raw.storeName()))
+                        categoryMap.getOrDefault(raw.storeName(), 0L)
                 ))
                 .toList();
     }
@@ -58,12 +58,5 @@ public class ExpenseParseService {
         } catch (Exception e) {
             return Collections.emptyMap();
         }
-    }
-
-    private CategoryType findCategory(Long id) {
-        return Arrays.stream(CategoryType.values())
-                .filter(c -> c.getId().equals(id))
-                .findFirst()
-                .orElse(CategoryType.ETC);
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -21,3 +21,4 @@ spring:
 gemini:
   api:
     key: ${GOOGLE_GEMINI_KEY}
+    url: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent

--- a/src/main/resources/static/js/recommendation/input.js
+++ b/src/main/resources/static/js/recommendation/input.js
@@ -20,8 +20,7 @@ function renderMappingModal() {
 
     rawAnalysisResults.forEach((item, index) => {
         const categoryOptions = CATEGORIES.map(cat => {
-            const selected = item.categoryType === cat.toString() ? 'selected'
-                : '';
+            const selected = item.categoryId === cat.id ? 'selected' : '';
             return `<option value="${cat.id}" ${selected}>${cat.name}</option>`;
         }).join('');
         body.innerHTML += `

--- a/src/main/resources/static/js/recommendation/input.js
+++ b/src/main/resources/static/js/recommendation/input.js
@@ -21,8 +21,12 @@ async function analyzeExcel() {
             method: 'POST',
             body: formData
         });
-        rawAnalysisResults = await response.json();
 
+        if (!response.ok) {
+            throw new Error('서버 오류가 발생했습니다.');
+        }
+
+        rawAnalysisResults = await response.json();
         renderMappingModal();
     } catch (error) {
         alert('분석 중 오류가 발생했습니다.');
@@ -37,21 +41,34 @@ function renderMappingModal() {
     body.innerHTML = '';
 
     rawAnalysisResults.forEach((item, index) => {
-        const categoryOptions = CATEGORIES.map(cat => {
-            const selected = item.categoryId === cat.id ? 'selected' : '';
-            return `<option value="${cat.id}" ${selected}>${cat.name}</option>`;
-        }).join('');
-        body.innerHTML += `
-            <tr>
-                  <td>${item.storeName}</td>
-                  <td>${item.amount.toLocaleString()}원</td>
-                  <td>
-                      <select class="form-select mapping-select"  data-amount="${item.amount}">
-                          ${categoryOptions}
-                      </select>
-                  </td>
-              </tr>`;
+        const tr = document.createElement('tr');
+
+        const tdStore = document.createElement('td');
+        tdStore.textContent = item.storeName;
+        tr.appendChild(tdStore);
+
+        const tdAmount = document.createElement('td');
+        tdAmount.textContent = item.amount.toLocaleString() + '원';
+        tr.appendChild(tdAmount);
+
+        const tdCategory = document.createElement('td');
+        const select = document.createElement('select');
+        select.className = 'form-select mapping-select';
+        select.dataset.amount = item.amount;
+
+        CATEGORIES.forEach(cat => {
+            const option = document.createElement('option');
+            option.value = cat.id;
+            option.textContent = cat.name;
+            if (item.categoryId === cat.id) option.selected = true;
+            select.appendChild(option);
+        });
+
+        tdCategory.appendChild(select);
+        tr.appendChild(tdCategory);
+        body.appendChild(tr);
     });
+
     document.getElementById('mappingModal').style.display = 'block';
 }
 

--- a/src/main/resources/static/js/recommendation/input.js
+++ b/src/main/resources/static/js/recommendation/input.js
@@ -1,17 +1,35 @@
 let rawAnalysisResults = [];
 
+document.getElementById('excelFile').addEventListener('change', function () {
+    const btn = document.getElementById('analyzeBtn');
+    btn.disabled = !this.files.length;
+})
+
 async function analyzeExcel() {
-    const file = document.getElementById('excelFile').files[0];
-    const formData = new FormData();
-    formData.append('file', file);
+    const btn = document.getElementById('analyzeBtn');
+    const originalText = btn.textContent;
 
-    const response = await fetch('/api/recommendation/upload', {
-        method: 'POST',
-        body: formData
-    });
-    rawAnalysisResults = await response.json();
+    btn.disabled = true;
+    btn.textContent = '분석 중...';
 
-    renderMappingModal();
+    try {
+        const file = document.getElementById('excelFile').files[0];
+        const formData = new FormData();
+        formData.append('file', file);
+
+        const response = await fetch('/api/recommendation/upload', {
+            method: 'POST',
+            body: formData
+        });
+        rawAnalysisResults = await response.json();
+
+        renderMappingModal();
+    } catch (error) {
+        alert('분석 중 오류가 발생했습니다.');
+    } finally {
+        btn.disabled = false;
+        btn.textContent = originalText;
+    }
 }
 
 function renderMappingModal() {
@@ -52,9 +70,9 @@ function applyToManualForm() {
 
     for (const catId in totals) {
         const input = document.getElementById('amount-' + catId);
-        if (input) input.value = totals[catId];
+        if (input) input.value = formatNumber(totals[catId]);
     }
-    document.getElementById('expectedPerformance').value = totalPerformance;
+    document.getElementById('expectedPerformance').value = formatNumber(totalPerformance);
 
     alert('데이터가 합산되어 반영되었습니다');
     closeModal();
@@ -63,3 +81,35 @@ function applyToManualForm() {
 function closeModal() {
     document.getElementById('mappingModal').style.display = 'none';
 }
+
+function formatNumber(num) {
+    return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
+
+function unformatNumber(str) {
+    return str.replace(/,/g, '');
+}
+
+document.querySelectorAll('.category-input, #expectedPerformance').forEach(input => {
+    input.addEventListener('focus', function() {
+        this.select();
+    });
+});
+
+document.querySelectorAll('.category-input, #expectedPerformance').forEach(input => {
+    input.addEventListener('input', function() {
+        const value = this.value.replace(/[^\d]/g, '');
+        if (value !== '') {
+            this.value = formatNumber(value);
+        } else {
+            this.value = '';
+        }
+    });
+});
+
+document.getElementById('mainForm').addEventListener('submit', function() {
+    this.querySelectorAll('.category-input, #expectedPerformance').forEach(input => {
+        input.value = unformatNumber(input.value);
+    });
+});
+

--- a/src/main/resources/static/js/recommendation/input.js
+++ b/src/main/resources/static/js/recommendation/input.js
@@ -1,0 +1,66 @@
+let rawAnalysisResults = [];
+
+async function analyzeExcel() {
+    const file = document.getElementById('excelFile').files[0];
+    const formData = new FormData();
+    formData.append('file', file);
+
+    const response = await fetch('/api/recommendation/upload', {
+        method: 'POST',
+        body: formData
+    });
+    rawAnalysisResults = await response.json();
+
+    renderMappingModal();
+}
+
+function renderMappingModal() {
+    const body = document.getElementById('mappingTableBody');
+    body.innerHTML = '';
+
+    rawAnalysisResults.forEach((item, index) => {
+        const categoryOptions = CATEGORIES.map(cat => {
+            const selected = item.categoryType === cat.toString() ? 'selected'
+                : '';
+            return `<option value="${cat.id}" ${selected}>${cat.name}</option>`;
+        }).join('');
+        body.innerHTML += `
+            <tr>
+                  <td>${item.storeName}</td>
+                  <td>${item.amount.toLocaleString()}원</td>
+                  <td>
+                      <select class="form-select mapping-select"  data-amount="${item.amount}">
+                          ${categoryOptions}
+                      </select>
+                  </td>
+              </tr>`;
+    });
+    document.getElementById('mappingModal').style.display = 'block';
+}
+
+function applyToManualForm() {
+    const selects = document.querySelectorAll('.mapping-select');
+    const totals = {};
+    let totalPerformance = 0;
+
+    selects.forEach(select => {
+        const catId = select.value;
+        const amount = parseInt(select.dataset.amount);
+
+        totals[catId] = (totals[catId] || 0) + amount;
+        totalPerformance += amount;
+    });
+
+    for (const catId in totals) {
+        const input = document.getElementById('amount-' + catId);
+        if (input) input.value = totals[catId];
+    }
+    document.getElementById('expectedPerformance').value = totalPerformance;
+
+    alert('데이터가 합산되어 반영되었습니다');
+    closeModal();
+}
+
+function closeModal() {
+    document.getElementById('mappingModal').style.display = 'none';
+}

--- a/src/main/resources/static/js/recommendation/input.js
+++ b/src/main/resources/static/js/recommendation/input.js
@@ -73,13 +73,19 @@ function renderMappingModal() {
 }
 
 function applyToManualForm() {
+    document.querySelectorAll('.category-input').forEach(input => {
+        input.value = formatNumber(0);
+    })
+    document.getElementById('expectedPerformance').value = formatNumber(0);
+
     const selects = document.querySelectorAll('.mapping-select');
     const totals = {};
     let totalPerformance = 0;
 
     selects.forEach(select => {
         const catId = select.value;
-        const amount = parseInt(select.dataset.amount);
+        const amount = Number(select.dataset.amount);
+        if (Number.isNaN(amount)) return;
 
         totals[catId] = (totals[catId] || 0) + amount;
         totalPerformance += amount;

--- a/src/main/resources/templates/recommendation/input.html
+++ b/src/main/resources/templates/recommendation/input.html
@@ -2,22 +2,53 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>카드 추천 - 수기 입력</title>
+    <title>카드 추천 입력</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css">
 </head>
 <body>
-    <h1>소비 내역 수기 입력</h1>
-    <p>한 달 동안 사용하신 카테고리별 금액을 입력해주세요.</p>
+    <div class="container mt-5">
+        <h2 class="mb-4">소비 패턴 입력</h2>
+        <p>한 달 동안 사용하신 카테고리별 금액을 입력해주세요.</p>
 
-    <form th:action="@{/recommendation/manual}" th:object="${manualInputForm}" method="post">
-        <div>
-            <label>예상 전월 실적: </label>
-            <input type="number" th:field="*{expectedPerformance}" placeholder="예: 300000"> 원
+        <div class="card p-3 mb-4">
+            <h5>엑셀로 데이터 불러오기</h5>
+            <input type="file" id="excelFile" class="form-control">
+            <button type="button" class="btn btn-secondary mt-2" onclick="analyzeExcel()">분석하기</button>
         </div>
 
-        <hr>
-        <p>현재는 예시 화면입니다. 실제 리스트 입력은 다음 단계에서 구현합니다.</p>
+        <form th:action="@{/recommendation/result}" method="POST" id="mainForm">
+            <div class="mb-3">
+                <label>예상 전월 실적: </label>
+                <input type="number" name="expectedPerformance" id="expectedPerformance" class="form-control" value="0">
+            </div>
 
-        <button type="submit">추천 받기</button>
-    </form>
+            <div th:each="cat, stat : ${categories}" class="mb-2 row">
+                <div class="col-4" th:text="${cat.name}">식비</div>
+                <div class="col-8">
+                    <input type="hidden" th:name="|items[${stat.index}].categoryId|" th:value="${cat.id}">
+                    <input type="number" th:name="|items[${stat.index}].amount|" th:id="'amount-' + ${cat.id}"
+                           class="form-control category-input" value="0">
+                </div>
+            </div>
+            <button type="submit" class="btn btn-primary w-100">추천 카드 분석</button>
+        </form>
+    </div>
+
+    <div id="mappingModal" class="modal" style="display:none; position:fixed; top:10%; left:10%; width:80%; height:80%; background:white; border:1px solid #ccc; z-index:1000; padding:20px; overflow-y:auto;">
+        <h4>AI 분류 결과 확인/수정</h4>
+        <table class="table">
+            <thead>
+                <tr><th>가맹점/내역</th><th>금액</th><th>분류</th></tr>
+            </thead>
+            <tbody id="mappingTableBody"></tbody>
+        </table>
+        <button class="btn btn-success" onclick="applyToManualForm()">이 대로 합산 적용</button>
+        <button class="btn btn-danger" onclick="closeModal()">닫기</button>
+    </div>
+
+    <script th:inline="javascript">
+        const CATEGORIES = /*[[${categoriesForJs}]]*/ [];
+    </script>
+    <script th:src="@{/js/recommendation/input.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/recommendation/input.html
+++ b/src/main/resources/templates/recommendation/input.html
@@ -13,20 +13,20 @@
         <div class="card p-3 mb-4">
             <h5>엑셀로 데이터 불러오기</h5>
             <input type="file" id="excelFile" class="form-control">
-            <button type="button" class="btn btn-secondary mt-2" onclick="analyzeExcel()">분석하기</button>
+            <button type="button" id="analyzeBtn" class="btn btn-secondary mt-2" onclick="analyzeExcel()" disabled>분석하기</button>
         </div>
 
         <form th:action="@{/recommendation/result}" method="POST" id="mainForm">
             <div class="mb-3">
                 <label>예상 전월 실적: </label>
-                <input type="number" name="expectedPerformance" id="expectedPerformance" class="form-control" value="0">
+                <input type="text" inputmode="numeric" name="expectedPerformance" id="expectedPerformance" class="form-control" value="0">
             </div>
 
             <div th:each="cat, stat : ${categories}" class="mb-2 row">
                 <div class="col-4" th:text="${cat.name}">식비</div>
                 <div class="col-8">
                     <input type="hidden" th:name="|items[${stat.index}].categoryId|" th:value="${cat.id}">
-                    <input type="number" th:name="|items[${stat.index}].amount|" th:id="'amount-' + ${cat.id}"
+                    <input type="text" inputmode="numeric" th:name="|items[${stat.index}].amount|" th:id="'amount-' + ${cat.id}"
                            class="form-control category-input" value="0">
                 </div>
             </div>

--- a/src/test/java/org/example/cardfit/infrastructure/excel/PoiExcelParserTest.java
+++ b/src/test/java/org/example/cardfit/infrastructure/excel/PoiExcelParserTest.java
@@ -1,0 +1,58 @@
+package org.example.cardfit.infrastructure.excel;
+
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.assertj.core.api.Assertions;
+import org.example.cardfit.recommendation.dto.RawExpense;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.ByteArrayOutputStream;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+class PoiExcelParserTest {
+
+    private final PoiExcelParser parser = new PoiExcelParser();
+
+    @Test
+    @DisplayName("엑셀 파일을 업로드하면 RawExpense 리스트로 정확히 변환되어야 한다")
+    void shouldParserExcelFileCorrectly() throws Exception {
+        // given: 가짜 엑셀 파일 (.xlsx 구조)
+        Workbook workbook = new XSSFWorkbook();
+        Sheet sheet = workbook.createSheet("TestSheet");
+
+        Row header = sheet.createRow(0);
+        header.createCell(0).setCellValue("날짜");
+        header.createCell(1).setCellValue("가맹점명");
+        header.createCell(2).setCellValue("금액");
+
+        Row dataRow = sheet.createRow(1);
+        dataRow.createCell(0).setCellValue(LocalDate.of(2026, 1, 27));
+        dataRow.createCell(1).setCellValue("스타벅스 성수점");
+        dataRow.createCell(2).setCellValue(5500);
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        workbook.write(bos);
+        MockMultipartFile mockFile = new MockMultipartFile(
+                "file", "test.xlsx",
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                bos.toByteArray()
+        );
+
+        // when
+        List<RawExpense> result = parser.parse(mockFile);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).storeName()).isEqualTo("스타벅스 성수점");
+        assertThat(result.get(0).amount()).isEqualTo(5500);
+        assertThat(result.get(0).date()).isEqualTo(LocalDate.of(2026, 1, 27));
+    }
+
+}

--- a/src/test/java/org/example/cardfit/infrastructure/excel/PoiExcelParserTest.java
+++ b/src/test/java/org/example/cardfit/infrastructure/excel/PoiExcelParserTest.java
@@ -4,21 +4,36 @@ import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
-import org.assertj.core.api.Assertions;
 import org.example.cardfit.recommendation.dto.RawExpense;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.springframework.mock.web.MockMultipartFile;
 
 import java.io.ByteArrayOutputStream;
 import java.time.LocalDate;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 class PoiExcelParserTest {
 
-    private final PoiExcelParser parser = new PoiExcelParser();
+    @Mock
+    private HeaderDetector headerDetector;
+
+    private PoiExcelParser parser;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        parser = new PoiExcelParser(headerDetector);
+
+        when(headerDetector.detect(any())).thenReturn(new ColumnMapping(0, 1, 2, -1));
+    }
 
     @Test
     @DisplayName("엑셀 파일을 업로드하면 RawExpense 리스트로 정확히 변환되어야 한다")

--- a/src/test/java/org/example/cardfit/infrastructure/llm/GeminiClientTest.java
+++ b/src/test/java/org/example/cardfit/infrastructure/llm/GeminiClientTest.java
@@ -1,0 +1,48 @@
+package org.example.cardfit.infrastructure.llm;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+class GeminiClientTest {
+
+    @Autowired
+    private GeminiClient geminiClient;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("실제 Gemini API가 정해진 카테고리 ID로 JSON 응답을 주는지 확인")
+    void realApiTest() {
+        // given
+        List<String> stores = List.of("스타벅스 성수점", "배민", "GS25 강남점", "아아");
+
+        // when
+        String response = geminiClient.classify(stores);
+        System.out.println("Gemini Response: " + response);
+
+        // then
+        List<Map<String, Object>> result = objectMapper.readValue(response, new TypeReference<>() {});
+
+        assertThat(response).isNotEmpty();
+        assertThat(result.get(0)).containsKey("storeName");
+        assertThat(result.get(0)).containsKey("categoryId");
+
+        Object categoryId = result.get(0).get("categoryId");
+        System.out.println("Parsed CategoryId: " + categoryId);
+
+        assertThat(categoryId.toString()).matches("\\d+");
+    }
+
+}

--- a/src/test/java/org/example/cardfit/infrastructure/llm/GeminiClientTest.java
+++ b/src/test/java/org/example/cardfit/infrastructure/llm/GeminiClientTest.java
@@ -1,7 +1,9 @@
 package org.example.cardfit.infrastructure.llm;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -24,7 +26,11 @@ class GeminiClientTest {
 
     @Test
     @DisplayName("실제 Gemini API가 정해진 카테고리 ID로 JSON 응답을 주는지 확인")
-    void realApiTest() {
+    @Tag("integration")
+    void realApiTest() throws Exception {
+        Assumptions.assumeTrue(System.getenv("GEMINI_API_KEY") != null,
+                "GEMINI_API_KEY not set");
+
         // given
         List<String> stores = List.of("스타벅스 성수점", "배민", "GS25 강남점", "아아");
 

--- a/src/test/java/org/example/cardfit/recommendation/service/ExpenseParseServiceTest.java
+++ b/src/test/java/org/example/cardfit/recommendation/service/ExpenseParseServiceTest.java
@@ -1,0 +1,56 @@
+package org.example.cardfit.recommendation.service;
+
+import org.example.cardfit.domain.category.CategoryType;
+import org.example.cardfit.infrastructure.excel.PoiExcelParser;
+import org.example.cardfit.recommendation.dto.ExpenseMappingResult;
+import org.example.cardfit.recommendation.dto.RawExpense;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest
+class ExpenseParseServiceTest {
+
+    @MockitoBean
+    private PoiExcelParser excelParser;
+
+    @Autowired
+    private ExpenseParseService expenseParseService;
+
+    @Test
+    @DisplayName("엑셀 파일을 업로드하면 AI가 카테고리를 매핑하여 결과를 반환한다")
+    void parseAndClassifyTest() {
+        // given
+        List<RawExpense> mockRawExpenses = List.of(
+                new RawExpense(LocalDate.of(2026, 01, 27), "스타벅스", 5000L),
+                new RawExpense(LocalDate.of(2026, 01, 27), "배달의민족", 25000L)
+        );
+        given(excelParser.parse(any())).willReturn(mockRawExpenses);
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "test.xlsx",
+                "text/plain",
+                "dummy".getBytes()
+        );
+
+        // when
+        List<ExpenseMappingResult> results = expenseParseService.parseAndClassify(file);
+
+        // then
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0).categoryType()).isEqualTo(CategoryType.COFFEE);
+        assertThat(results.get(1).categoryType()).isNotEqualTo(CategoryType.ETC);
+    }
+
+}

--- a/src/test/java/org/example/cardfit/recommendation/service/ExpenseParseServiceTest.java
+++ b/src/test/java/org/example/cardfit/recommendation/service/ExpenseParseServiceTest.java
@@ -2,6 +2,7 @@ package org.example.cardfit.recommendation.service;
 
 import org.example.cardfit.domain.category.CategoryType;
 import org.example.cardfit.infrastructure.excel.PoiExcelParser;
+import org.example.cardfit.infrastructure.llm.LLMClient;
 import org.example.cardfit.recommendation.dto.ExpenseMappingResult;
 import org.example.cardfit.recommendation.dto.RawExpense;
 import org.junit.jupiter.api.DisplayName;
@@ -24,6 +25,9 @@ class ExpenseParseServiceTest {
     @MockitoBean
     private PoiExcelParser excelParser;
 
+    @MockitoBean
+    private LLMClient llmClient;
+
     @Autowired
     private ExpenseParseService expenseParseService;
 
@@ -36,6 +40,9 @@ class ExpenseParseServiceTest {
                 new RawExpense(LocalDate.of(2026, 01, 27), "배달의민족", 25000L)
         );
         given(excelParser.parse(any())).willReturn(mockRawExpenses);
+        given(llmClient.classify(any())).willReturn(
+                "[{\"storeName\":\"스타벅스\",\"categoryId\":1},{\"storeName\":\"배달의민족\",\"categoryId\":2}]"
+        );
 
         MockMultipartFile file = new MockMultipartFile(
                 "file",
@@ -49,8 +56,7 @@ class ExpenseParseServiceTest {
 
         // then
         assertThat(results).hasSize(2);
-        assertThat(results.get(0).categoryType()).isEqualTo(CategoryType.COFFEE);
-        assertThat(results.get(1).categoryType()).isNotEqualTo(CategoryType.ETC);
+        assertThat(results.get(0).categoryId()).isEqualTo(1L);
     }
 
 }


### PR DESCRIPTION
## 📌 개요                                    
  엑셀 파일 업로드를 통해 소비 내역을 자동으로 파싱하고, LLM(Gemini)을 활용하여 카테고리를 자동 분류하는 기능 구현                       
                                                
  ## 📝 작업 내용                               
  - [x] Apache POI 의존성 추가 및 엑셀 파서 구현
  - [x] 프로젝트 공통 카테고리 Enum 정의        
  - [x] LLMClient 추상화 및 Gemini API 연동     
  - [x] 엑셀 헤더 자동 감지 및 LLM 폴백 처리    
  - [x] 지출 내역만 필터링 (수입/지출 열 또는 금액 부호 기반)                               
  - [x] 공과금/생활비 카테고리 추가             
  - [x] 엑셀 업로드 프론트엔드 및 카테고리 매핑  UI 구현                                       
  - [x] 분석 UI 개선 (로딩 표시, 금액 포맷팅,  버튼 비활성화)                                
                                                
  ## 🧪 테스트 결과
  - ExpenseParseService 테스트 통과            
                                                
  ## 🔗 관련 이슈                               
  - close #3      

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Excel 파일 업로드로 지출 일괄 입력 및 분석 파이프라인 추가
  * AI 기반 자동 카테고리 분류 및 결과 매핑 UI(모달) 제공
  * 엑셀 헤더 자동 탐지 및 유연한 파싱/매핑 흐름 도입
  * 카테고리 타입과 매핑 결과 표현용 데이터 구조 추가

* **구성 변경**
  * POI 라이브러리를 OOXML 변종으로 변경 및 Gemini API 엔드포인트 설정 추가

* **테스트**
  * 파서 및 LLM 연동 관련 단위·통합 테스트 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->